### PR TITLE
Fixes NPC algorithms not scaling with NPC level

### DIFF
--- a/Adder/eventSheets/Systems/Game Systems/AI.json
+++ b/Adder/eventSheets/Systems/Game Systems/AI.json
@@ -552,28 +552,37 @@
 												{
 													"id": "set-instvar-value",
 													"objectClass": "NPC",
-													"sid": 381749746431741,
+													"sid": 536609884715668,
+													"parameters": {
+														"instance-variable": "Level",
+														"value": "floor(random(1,level_Difficulty + 0.99))"
+													}
+												},
+												{
+													"id": "set-instvar-value",
+													"objectClass": "NPC",
+													"sid": 643124993528133,
 													"parameters": {
 														"instance-variable": "MaxHP",
-														"value": "ceil(NPC_Parent.HP_Base^(NPC_Parent.HP_Constant+(NPC_Parent.HP_Rate*NPC.Level)))"
+														"value": "ceil(NPC_Parent.HP_Base^(NPC_Parent.HP_Constant+(NPC_Parent.HP_Rate+NPC.Level/50)))"
 													}
 												},
 												{
 													"id": "set-instvar-value",
 													"objectClass": "NPC",
-													"sid": 977686457337850,
+													"sid": 288915282298282,
 													"parameters": {
 														"instance-variable": "Loot_XP",
-														"value": "(NPC_Parent.XP_Base^(NPC_Parent.XP_Constant+(NPC_Parent.XP_Rate*NPC.Level)))"
+														"value": "(NPC_Parent.XP_Base^(NPC_Parent.XP_Constant+(NPC_Parent.XP_Rate+NPC.Level/50)))"
 													}
 												},
 												{
 													"id": "set-instvar-value",
 													"objectClass": "NPC",
-													"sid": 443605857147172,
+													"sid": 809956476112979,
 													"parameters": {
 														"instance-variable": "Loot_Money",
-														"value": "(NPC_Parent.Money_Base^(NPC_Parent.Money_Constant+(NPC_Parent.Money_Rate*NPC.Level)))"
+														"value": "(NPC_Parent.Money_Base^(NPC_Parent.Money_Constant+(NPC_Parent.Money_Rate+NPC.Level/50)))"
 													}
 												},
 												{
@@ -1111,15 +1120,6 @@
 													"parameters": {
 														"instance-variable": "HasLimp",
 														"value": "NPC_Parent.Limp"
-													}
-												},
-												{
-													"id": "set-instvar-value",
-													"objectClass": "NPC",
-													"sid": 671983728024844,
-													"parameters": {
-														"instance-variable": "Level",
-														"value": "floor(random(1,level_Difficulty + 0.99))"
 													}
 												},
 												{

--- a/Adder/project.c3proj
+++ b/Adder/project.c3proj
@@ -3560,7 +3560,7 @@
 	},
 	"properties": {
 		"description": "Adder",
-		"version": "0.6.2",
+		"version": "0.6.3",
 		"author": "",
 		"authorEmail": "",
 		"authorWebsite": "",


### PR DESCRIPTION
Adjusted MaxHP, Loot_XP and Loot_Money algorithms.
Fixes NPC MaxHP not scaling with NPC level unless enemies transforming into crawl state.
Fixes NPC Loot_XP not scaling with NPC level.
Fixes NPC Loot_Money not scaling with NPC level.
Fixes https://github.com/ReflextionsDev/Adder/issues/11

MaxHP, Loot_XP and Loot_Money were accessing the NPC level variable prior initialization. As such the algorithms always assumed NPC level 0, which resulted in all NPCs not scaling with their level at all. While NPCs which fell from walking into crawl state had the NPC level initialized already, so these were the only NPCs scaling with their level. Due to the nature of the algorithms, their values scaled into extremes.


**Notice:**
Enemy HP pool at higher levels is now significantly increased, but have also become more rewarding (XP/Money gained).
For example a lvl 10 boomer would have something around 320 HP now. Which should be reasonable at such a high difficulty, but may require further tweaking.